### PR TITLE
Add planets/Moon, constellation names, automated DST; fix #2 alignment; use uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 ###################
 *.svg
+
+# uv / Python
+.venv/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # starmap-svg
-for generating svg starmaps from selected coordinates and time 
+for generating svg starmaps from selected coordinates and time
 
-## Requirements 
-	Python > 3.2 
-	pip install svgwrite
+## Requirements
+
+Python ≥ 3.8, with [`uv`](https://docs.astral.sh/uv/) managing the
+dependencies:
+
+	uv sync
+
+Alternatively, `pip install svgwrite` still works for a manual setup.
 
 ## Usage
-	python starmap.py -h
+	uv run python starmap.py -h
 
 	optional arguments:
 	  -h, --help            show this help message and exit
@@ -27,6 +32,8 @@ for generating svg starmaps from selected coordinates and time
 	                        draw guides True/False
 	  -constellation [CONSTELLATION], --constellation [CONSTELLATION]
 	                        show constellation True/False
+	  -constellation_names [CONSTELLATION_NAMES], --constellation_names [CONSTELLATION_NAMES]
+	                        print constellation full names True/False
 	  -planets [PLANETS], --planets [PLANETS]
 	                        draw Sun, Moon and planets True/False
 	  -o OUTPUT, --output OUTPUT
@@ -42,20 +49,29 @@ for generating svg starmaps from selected coordinates and time
 
 
 ## Example 1
-	python starmap.py -coord 60.186,24.959 -time 12.00.00 -date 01.01.2000 -utc +2 -constellation True
+	uv run python starmap.py -coord 60.186,24.959 -time 12.00.00 -date 01.01.2000 -utc +2 -constellation True
 
 ![image](https://github.com/skeletor-git/starmap-svg/blob/master/example/starmap.png)
 
 ## Example 2
-	python starmap.py -coord 35.684,139.728 -time 20.00.00 -date 15.07.2018 -utc +9 -info TOKYO -guides True -magn 10.0 -width 150 -height 220
+	uv run python starmap.py -coord 35.684,139.728 -time 20.00.00 -date 15.07.2018 -utc +9 -info TOKYO -guides True -magn 10.0 -width 150 -height 220
 
 ![image](https://github.com/skeletor-git/starmap-svg/blob/master/example/starmap2.png)
+
+## Example 3 — planets, constellation names, auto DST
+
+	uv run python starmap.py -coord 60.186,24.959 -time 22.00.00 -date 22.07.2024 -utc +2 \
+	    -constellation True -constellation_names True -planets True
 
 
 ## Info
 
 Stars data: "Yale Bright Star Catalog ver5"
 http://tdc-www.harvard.edu/catalogs/bsc5.html
+
+Sky orientation uses the IAU 1982 low-precision GMST formula; the
+J2000 star and constellation-line positions are precessed to the epoch
+of the given date (Meeus, chapter 21).
 
 Planet / Sun / Moon positions are computed with the simplified Keplerian
 algorithm from Paul Schlyter's "How to compute planetary positions"

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ for generating svg starmaps from selected coordinates and time
 	  -magn [MAGN], --magn [MAGN]
 	                        magnitude limit 0.1-12.0
 	  -summertime [SUMMERTIME], --summertime [SUMMERTIME]
-	                        if it is summertime on the date of the starchart
+	                        summertime/DST: auto (default), true, false
 	  -guides [GUIDES], --guides [GUIDES]
 	                        draw guides True/False
 	  -constellation [CONSTELLATION], --constellation [CONSTELLATION]
 	                        show constellation True/False
+	  -planets [PLANETS], --planets [PLANETS]
+	                        draw Sun, Moon and planets True/False
 	  -o OUTPUT, --output OUTPUT
 	                        output filename.svg
 	  -width [WIDTH], --width [WIDTH]
@@ -55,5 +57,12 @@ for generating svg starmaps from selected coordinates and time
 Stars data: "Yale Bright Star Catalog ver5"
 http://tdc-www.harvard.edu/catalogs/bsc5.html
 
-## TODO
-	Planets and Moon orbits, Automated summertime.
+Planet / Sun / Moon positions are computed with the simplified Keplerian
+algorithm from Paul Schlyter's "How to compute planetary positions"
+(http://stjarnhimlen.se/comp/ppcomp.html), including the main solar
+perturbations of the Moon.
+
+Automated summertime applies the EU rule in the northern hemisphere
+(last Sunday of March → last Sunday of October) and the AU-style rule
+in the southern hemisphere (first Sunday of October → first Sunday of
+April). Pass `-summertime true|false` to override.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "starmap-svg"
+version = "0.2.0"
+description = "Generate SVG starmaps for selected coordinates and time."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+dependencies = [
+    "svgwrite>=1.4",
+]
+
+[tool.uv]
+package = false

--- a/starmap.py
+++ b/starmap.py
@@ -1,8 +1,9 @@
 
 import svgwrite
-import random 
+import random
 import math
 import argparse
+import calendar
 
 ############ DEFAULT VALUES AND CONSTS ####################################
 
@@ -17,10 +18,10 @@ constellation_color = "rgb(255,255,255)"
 output_file = 'starmap.svg'
 
 #Date & Time
-date = '01.01.2000' 
+date = '01.01.2000'
 time = '12.00.00'
 utc = 2
-summertime = False
+summertime = 'auto'
 
 #Coordinates
 coord = "60.186,24.959"
@@ -28,6 +29,7 @@ coord = "60.186,24.959"
 fullview = False
 guides = False
 constellation = False
+planets = False
 
 #placetext for leftdown corner
 info = 'HELSINKI'
@@ -108,6 +110,234 @@ def read_constellation_file():
 
 
 
+############ SUMMERTIME (DST) DETECTION ##################################
+
+# Automated DST detection. Rules used:
+#   Northern hemisphere — EU rule: last Sunday of March → last Sunday of October.
+#   Southern hemisphere — approximate (AU-style): first Sunday of October →
+#   first Sunday of April. Users with a different local rule can still pass
+#   -summertime true / false explicitly.
+
+def _last_sunday_of_month(year, month):
+	_, last_day = calendar.monthrange(year, month)
+	offset = (calendar.weekday(year, month, last_day) - calendar.SUNDAY) % 7
+	return last_day - offset
+
+def _first_sunday_of_month(year, month):
+	first_wd = calendar.weekday(year, month, 1)
+	offset = (calendar.SUNDAY - first_wd) % 7
+	return 1 + offset
+
+def _detect_summertime(date_str, latitude):
+	day   = int(date_str[0:2])
+	month = int(date_str[3:5])
+	year  = int(date_str[6:10])
+
+	if latitude >= 0:
+		# Northern hemisphere — EU rule
+		if month < 3 or month > 10:
+			return False
+		if 3 < month < 10:
+			return True
+		if month == 3:
+			return day >= _last_sunday_of_month(year, 3)
+		return day < _last_sunday_of_month(year, 10)  # month == 10
+	else:
+		# Southern hemisphere (AU-style)
+		if month > 10 or month < 4:
+			return True
+		if 4 < month < 10:
+			return False
+		if month == 10:
+			return day >= _first_sunday_of_month(year, 10)
+		return day < _first_sunday_of_month(year, 4)  # month == 4
+
+def _parse_summertime_arg(v):
+	if v is None:
+		return 'auto'
+	s = str(v).strip().lower()
+	if s in ('', 'auto'):
+		return 'auto'
+	if s in ('true', 'yes', '1', 'on'):
+		return True
+	if s in ('false', 'no', '0', 'off'):
+		return False
+	raise argparse.ArgumentTypeError("summertime must be auto/true/false")
+
+def _parse_bool_arg(v):
+	if v is None:
+		return True
+	s = str(v).strip().lower()
+	if s in ('true', 'yes', '1', 'on', ''):
+		return True
+	if s in ('false', 'no', '0', 'off'):
+		return False
+	raise argparse.ArgumentTypeError("expected true/false")
+
+
+############ SOLAR SYSTEM BODIES #########################################
+
+# Keplerian orbital elements and daily rates from Paul Schlyter's
+# "How to compute planetary positions" — http://stjarnhimlen.se/comp/ppcomp.html
+# Entry format:
+#   [N0, N_rate, i0, i_rate, w0, w_rate, a0, a_rate, e0, e_rate, M0, M_rate]
+# where d is days since J2000.0 (2000 Jan 1, 0h UT, minus 1.5 per Schlyter).
+# Sun element set represents the reflex (Earth's) orbit; Moon elements are
+# already geocentric. Planets are heliocentric.
+
+_ORBITAL_ELEMENTS = {
+	'Sun':     [  0.0000,  0.0000000000,  0.0000,  0.000000e+00, 282.9404,  4.70935e-05,  1.000000,  0.00000e+00, 0.016709, -1.151e-09, 356.0470,  0.9856002585],
+	'Moon':    [125.1228, -0.0529538083,  5.1454,  0.000000e+00, 318.0634,  0.1643573223, 60.266600,  0.00000e+00, 0.054900,  0.000e+00, 115.3654, 13.0649929509],
+	'Mercury': [ 48.3313,  3.24587e-05,   7.0047,  5.000000e-08,  29.1241,  1.01444e-05,  0.387098,  0.00000e+00, 0.205635,  5.590e-10, 168.6562,  4.0923344368],
+	'Venus':   [ 76.6799,  2.46590e-05,   3.3946,  2.750000e-08,  54.8910,  1.38374e-05,  0.723330,  0.00000e+00, 0.006773, -1.302e-09,  48.0052,  1.6021302244],
+	'Mars':    [ 49.5574,  2.11081e-05,   1.8497, -1.780000e-08, 286.5016,  2.92961e-05,  1.523688,  0.00000e+00, 0.093405,  2.516e-09,  18.6021,  0.5240207766],
+	'Jupiter': [100.4542,  2.76854e-05,   1.3030, -1.557000e-07, 273.8777,  1.64505e-05,  5.202560,  0.00000e+00, 0.048498,  4.469e-09,  19.8950,  0.0830853001],
+	'Saturn':  [113.6634,  2.38980e-05,   2.4886, -1.081000e-07, 339.3939,  2.97661e-05,  9.554750,  0.00000e+00, 0.055546, -9.499e-09, 316.9670,  0.0334442282],
+	'Uranus':  [ 74.0005,  1.39780e-05,   0.7733,  1.900000e-08,  96.6612,  3.05650e-05, 19.181710, -1.55000e-08, 0.047318,  7.450e-09, 142.5905,  0.0117258060],
+	'Neptune': [131.7806,  3.01730e-05,   1.7700, -2.550000e-07, 272.8461, -6.02700e-06, 30.058260,  3.31300e-08, 0.008606,  2.150e-09, 260.2471,  0.0059951470],
+}
+
+# Display style — apparent size scaling and label color.
+_PLANET_STYLE = {
+	'Sun':     {'color': 'rgb(255,210, 80)', 'size': 3.0},
+	'Moon':    {'color': 'rgb(230,230,230)', 'size': 2.6},
+	'Mercury': {'color': 'rgb(190,190,190)', 'size': 1.3},
+	'Venus':   {'color': 'rgb(255,240,180)', 'size': 1.8},
+	'Mars':    {'color': 'rgb(255,120, 90)', 'size': 1.5},
+	'Jupiter': {'color': 'rgb(255,200,140)', 'size': 2.0},
+	'Saturn':  {'color': 'rgb(240,220,170)', 'size': 1.8},
+	'Uranus':  {'color': 'rgb(170,220,230)', 'size': 1.3},
+	'Neptune': {'color': 'rgb(140,170,230)', 'size': 1.3},
+}
+
+_PLANET_ORDER = ['Sun', 'Moon', 'Mercury', 'Venus', 'Mars',
+                 'Jupiter', 'Saturn', 'Uranus', 'Neptune']
+
+
+def _schlyter_day(date_str, time_str, utc_offset, dst_hour):
+	"""Days since 2000 Jan 0.0 TDT (Schlyter's d), incl. fractional UT."""
+	year  = int(date_str[6:10])
+	month = int(date_str[3:5])
+	day   = int(date_str[0:2])
+	hour   = float(time_str[0:2])
+	minute = float(time_str[3:5])
+	second = float(time_str[6:8])
+
+	d = (367*year
+	     - 7*(year + (month + 9)//12)//4
+	     + 275*month//9
+	     + day - 730530)
+	ut_hours = hour + minute/60.0 + second/3600.0 - utc_offset - dst_hour
+	return d + ut_hours/24.0
+
+
+def _solve_kepler(M_rad, e):
+	"""Iteratively solve Kepler's equation E - e*sin(E) = M."""
+	E = M_rad + e*math.sin(M_rad)*(1.0 + e*math.cos(M_rad))
+	for _ in range(10):
+		dE = (E - e*math.sin(E) - M_rad) / (1.0 - e*math.cos(E))
+		E -= dE
+		if abs(dE) < 1e-10:
+			break
+	return E
+
+
+def _orbital_state(body, d):
+	N0, Nr, i0, ir, w0, wr, a0, ar, e0, er, M0, Mr = _ORBITAL_ELEMENTS[body]
+	N_deg = (N0 + Nr*d) % 360
+	w_deg = (w0 + wr*d) % 360
+	M_deg = (M0 + Mr*d) % 360
+	N = math.radians(N_deg)
+	i = math.radians(i0 + ir*d)
+	w = math.radians(w_deg)
+	a = a0 + ar*d
+	e = e0 + er*d
+	M = math.radians(M_deg)
+	L = math.radians((N_deg + w_deg + M_deg) % 360)  # mean longitude
+	return N, i, w, a, e, M, L
+
+
+def _body_xyz(body, d):
+	"""Ecliptic rectangular coords. Heliocentric for planets, geocentric for Sun/Moon."""
+	N, i, w, a, e, M, _ = _orbital_state(body, d)
+	E = _solve_kepler(M, e)
+	xv = a*(math.cos(E) - e)
+	yv = a*math.sqrt(1.0 - e*e)*math.sin(E)
+	v = math.atan2(yv, xv)
+	r = math.hypot(xv, yv)
+	cos_vw = math.cos(v + w); sin_vw = math.sin(v + w)
+	x = r*(math.cos(N)*cos_vw - math.sin(N)*sin_vw*math.cos(i))
+	y = r*(math.sin(N)*cos_vw + math.cos(N)*sin_vw*math.cos(i))
+	z = r*sin_vw*math.sin(i)
+	return x, y, z
+
+
+def _moon_xyz(d):
+	"""Moon geocentric ecliptic xyz with Schlyter's main solar perturbations."""
+	x, y, z = _body_xyz('Moon', d)
+	lon  = math.atan2(y, x)
+	lat  = math.atan2(z, math.hypot(x, y))
+	dist = math.hypot(x, y, z)
+
+	Nm, _, _, _, _, Mm, Lm = _orbital_state('Moon', d)
+	_,  _, _, _, _, Ms, Ls = _orbital_state('Sun',  d)
+	D = Lm - Ls
+	F = Lm - Nm
+
+	dlon_deg = (
+		-1.274 * math.sin(Mm - 2*D)
+		+ 0.658 * math.sin(2*D)
+		- 0.186 * math.sin(Ms)
+		- 0.059 * math.sin(2*Mm - 2*D)
+		- 0.057 * math.sin(Mm - 2*D + Ms)
+		+ 0.053 * math.sin(Mm + 2*D)
+		+ 0.046 * math.sin(2*D - Ms)
+		+ 0.041 * math.sin(Mm - Ms)
+		- 0.035 * math.sin(D)
+		- 0.031 * math.sin(Mm + Ms)
+	)
+	dlat_deg = (
+		-0.173 * math.sin(F - 2*D)
+		- 0.055 * math.sin(Mm - F - 2*D)
+		- 0.046 * math.sin(Mm + F - 2*D)
+		+ 0.033 * math.sin(F + 2*D)
+		+ 0.017 * math.sin(2*Mm + F)
+	)
+	lon += math.radians(dlon_deg)
+	lat += math.radians(dlat_deg)
+
+	x = dist * math.cos(lat) * math.cos(lon)
+	y = dist * math.cos(lat) * math.sin(lon)
+	z = dist * math.sin(lat)
+	return x, y, z
+
+
+def solar_system_positions(d):
+	"""Return {body: (ra_rad, dec_rad)} geocentric equatorial coords at day d."""
+	sun = _body_xyz('Sun', d)
+	ecl = math.radians(23.4393 - 3.563e-7 * d)
+	cos_e = math.cos(ecl); sin_e = math.sin(ecl)
+
+	positions = {}
+	for name in _PLANET_ORDER:
+		if name == 'Sun':
+			x, y, z = sun
+		elif name == 'Moon':
+			x, y, z = _moon_xyz(d)
+		else:
+			xh, yh, zh = _body_xyz(name, d)
+			# heliocentric -> geocentric
+			x = xh + sun[0]; y = yh + sun[1]; z = zh + sun[2]
+
+		xe = x
+		ye = y*cos_e - z*sin_e
+		ze = y*sin_e + z*cos_e
+		ra  = math.atan2(ye, xe) % (2*math.pi)
+		dec = math.atan2(ze, math.hypot(xe, ye))
+		positions[name] = (ra, dec)
+	return positions
+
+
 ############ ARGPARSER ###################################################
 
 parser = argparse.ArgumentParser(description='Generate starmap svg file')
@@ -117,9 +347,10 @@ parser.add_argument('-date','--date', help='date in format day.month.year', defa
 parser.add_argument('-utc','--utc',nargs='?', help='utc of your location -12 to +12', type=int , default=utc)
 parser.add_argument('-magn','--magn',nargs='?', help='magnitude limit 0.1-12.0',type=float, default=magnitude_limit)
 
-parser.add_argument('-summertime','--summertime',nargs='?', help='if it is summertime on the date of the starchart',type=bool, default=summertime)
+parser.add_argument('-summertime','--summertime',nargs='?', help='summertime/DST: auto (default), true, false',type=_parse_summertime_arg, default=summertime, const='auto')
 parser.add_argument('-guides','--guides',nargs='?', help='draw guides True/False',type=bool, default=guides )
 parser.add_argument('-constellation','--constellation',nargs='?', help='show constellation True/False',type=bool, default=constellation )
+parser.add_argument('-planets','--planets',nargs='?', help='draw planets, Sun and Moon True/False',type=_parse_bool_arg, default=planets, const=True)
 parser.add_argument('-o','--output', help='output filename.svg',default='starmap.svg' )
 parser.add_argument('-width','--width',nargs='?', help='width in mm',type=int, default=width)
 parser.add_argument('-height','--height',nargs='?', help='height in mm',type=int, default=height)
@@ -138,6 +369,7 @@ guides = args.guides
 magnitude_limit = args.magn
 constellation = args.constellation
 summertime = args.summertime
+planets = args.planets
 
 height = args.height
 width = args.width
@@ -148,6 +380,13 @@ print("time",time)
 
 #latitude and longitude
 northern,eastern = map(float,coord.split(','))
+
+#Resolve automated summertime once coordinates are known
+if summertime == 'auto':
+	summertime = _detect_summertime(date, northern)
+	print("summertime (auto):", summertime)
+else:
+	print("summertime:", summertime)
 
 ########## DRAWING FUNCTIONS  ###########################################
 
@@ -351,6 +590,39 @@ def generate_constellations(northern_N,eastern_E,date,time):
 		if ((angle_from_viewpoint1 <= math.radians(90))  and (angle_from_viewpoint2 <= math.radians(90)) or fullview):
 			draw_line(half_x-x0,half_y-y0,half_x-x1,half_y-y1,line_color)
 
+def generate_planets(northern_N,eastern_E,date,time):
+	"""Draw Sun, Moon and the classical + outer planets for the given moment."""
+	N = math.radians(northern_N)
+	E = math.radians(eastern_E)
+
+	raddatetime = date_and_time_to_rad(date,time)
+
+	# Schlyter's day number uses UT — match what date_and_time_to_rad does.
+	dst_hour = 1 if summertime else 0
+	d = _schlyter_day(date, time, utc, dst_hour)
+	positions = solar_system_positions(d)
+
+	for name in _PLANET_ORDER:
+		ra, dec = positions[name]
+		ascension   = ra + raddatetime
+		declination = dec
+
+		angle_from_viewpoint = angle_between(N,E,declination,ascension)
+		if angle_from_viewpoint > math.radians(90) and not fullview:
+			continue
+
+		x,y = stereographic(N,E, declination, ascension, width-(borders))
+		style = _PLANET_STYLE[name]
+
+		image.add(image.circle(
+			(half_x-x, half_y-y), style['size'],
+			stroke=line_color, stroke_width="0.3", fill=style['color']))
+		image.add(image.text(
+			name,
+			insert=(half_x-x + style['size'] + 1.5, half_y-y - style['size']),
+			fill=style['color'], style=font_style2))
+
+
 ########## GENERATE SVG  ###########################################
 
 
@@ -363,7 +635,7 @@ if __name__ == '__main__':
 	half_x = mm_to_px(width/2)
 	half_y = mm_to_px(height/2)
 
-	#Svgfile 
+	#Svgfile
 	image = svgwrite.Drawing(output_file,size=(str(width)+'mm',str(height)+'mm'))
 
 	#Background
@@ -373,6 +645,8 @@ if __name__ == '__main__':
 	generate_starmap(northern,eastern,date,time)
 	if constellation:
 		generate_constellations(northern,eastern,date,time)
+	if planets:
+		generate_planets(northern,eastern,date,time)
 
 	#Text in bottom corner
 	image.add(image.text(info, insert=("20mm", str(height-21)+'mm'), fill=line_color, style=font_style))

--- a/starmap.py
+++ b/starmap.py
@@ -29,6 +29,7 @@ coord = "60.186,24.959"
 fullview = False
 guides = False
 constellation = False
+constellation_names = False
 planets = False
 
 #placetext for leftdown corner
@@ -55,12 +56,14 @@ aperture = 0.4
 file1 = "datafiles/ybsc5.txt"
 file2 = "datafiles/extradata.txt" #extra star data for magnitude 6,5 and higher
 file3 = "datafiles/constellation_lines.txt"
+file4 = "datafiles/constellation.txt" #3-letter IAU code -> full name
 
 data = []
 constellation_lines = []
+constellation_name_map = {}
 
-def hours_to_decimal(ra):##use this for ybsc5
-	
+def hours_to_decimal(ra):
+	# Kept for the extradata file where RA is stored as "HH.MMSS" style.
 	seconds  = float(ra[0:2])*60*60 	#hour
 	seconds += float(ra[3:5])*60	#minute
 	seconds += float(ra[5:7])		#seconds
@@ -69,19 +72,31 @@ def hours_to_decimal(ra):##use this for ybsc5
 
 
 def read_ybsc5():
+	# BSC5 byte layout (1-indexed per the catalog spec):
+	#   76-77 RAh  78-79 RAm  80-83 RAs    (J2000)
+	#   84    sign 85-86 DEd  87-88 DEm   89-90 DEs
+	#   103-107 Vmag
 	global data
 	with open(file1, 'rt') as f:
 		for line in f:
-			#RA,DEC,mag,constellation
-
-			if line[75:83].isspace() is False:
-				ra = line[75:77]+'.'+line[77:81]
-				ra = hours_to_decimal(ra)
-				dec = float(line[83:86]+'.'+line[87:90])
-				mag = float(line[103:107])
-				constellation = line[11:14]
-				greek = line[7:10]
-				data.append([ra,dec,mag,constellation,greek])
+			if line[75:83].isspace():
+				continue
+			try:
+				rah = int(line[75:77])
+				ram = int(line[77:79])
+				ras = float(line[79:83])
+				sign = -1.0 if line[83] == '-' else 1.0
+				ded = int(line[84:86])
+				dem = int(line[86:88])
+				des = int(line[88:90])
+				mag = float(line[102:107])
+			except ValueError:
+				continue
+			ra_deg  = (rah + ram/60.0 + ras/3600.0) * 15.0
+			dec_deg = sign * (ded + dem/60.0 + des/3600.0)
+			constellation = line[11:14]
+			greek = line[7:10]
+			data.append([ra_deg, dec_deg, mag, constellation, greek])
 				
 
 def read_extra_star_coordinate_file():
@@ -104,6 +119,15 @@ def read_constellation_file():
 			tmp[3] = float(tmp[3])*360/24
 			tmp[4] = float(tmp[4])
 			constellation_lines.append(tmp)
+
+
+def read_constellation_names():
+	"""Load 3-letter IAU code -> full name mapping into constellation_name_map."""
+	with open(file4, 'rt') as f:
+		for line in f:
+			parts = line.strip().split(None, 1)
+			if len(parts) == 2:
+				constellation_name_map[parts[0]] = parts[1]
 
 
 
@@ -350,6 +374,7 @@ parser.add_argument('-magn','--magn',nargs='?', help='magnitude limit 0.1-12.0',
 parser.add_argument('-summertime','--summertime',nargs='?', help='summertime/DST: auto (default), true, false',type=_parse_summertime_arg, default=summertime, const='auto')
 parser.add_argument('-guides','--guides',nargs='?', help='draw guides True/False',type=bool, default=guides )
 parser.add_argument('-constellation','--constellation',nargs='?', help='show constellation True/False',type=bool, default=constellation )
+parser.add_argument('-constellation_names','--constellation_names',nargs='?', help='print constellation full names True/False',type=_parse_bool_arg, default=constellation_names, const=True)
 parser.add_argument('-planets','--planets',nargs='?', help='draw planets, Sun and Moon True/False',type=_parse_bool_arg, default=planets, const=True)
 parser.add_argument('-o','--output', help='output filename.svg',default='starmap.svg' )
 parser.add_argument('-width','--width',nargs='?', help='width in mm',type=int, default=width)
@@ -368,6 +393,7 @@ output_file = args.output
 guides = args.guides
 magnitude_limit = args.magn
 constellation = args.constellation
+constellation_names = args.constellation_names
 summertime = args.summertime
 planets = args.planets
 
@@ -420,51 +446,58 @@ def draw_line(x0,y0,x1,y1,color):
 
 ########## TIME CALCULATION  ###########################################
 
-#date to days
-def date_and_time_to_rad(date,time):
+# The projection is centered at the observer's (latitude, longitude). For a
+# star to land at zenith when it crosses the local meridian, we need the
+# per-frame offset added to every star's RA to equal -GMST (Greenwich Mean
+# Sidereal Time). Then lon0 - lon in the stereographic projection works out
+# to the local hour angle.
 
-	#J2000 Epoch 01.01.2000 12.00.00
-	epochyear = 2000.0
-	epochhour = 12.0
-
-	calculation_mistake = -5.1
-
-	days_in_year = 365.2425
-	months = [31,28,31,30,31,30,31,31,30,31,30,31] #Array of days in months
-
-	year = int(date[6:10])
-	month  = int(date[3:5])
-	day    = int(date[0:2])
-	hour   = float(time[0:2])
-	minute = float(time[3:5])
-	second = float(time[6:8])
-
-	#years to days
-	daycounter = (year-epochyear)*days_in_year
-	#month to days
-	daycounter  += sum(months[0:month-1])	
-	#days
-	daycounter += day-1				
-
-	secondcounter  = (hour- epochhour+ calculation_mistake)*60*60
-	secondcounter  += minute*60
-	secondcounter += second			
-	
-	#Summertime
-	if(summertime):
-		secondcounter -= (60*60)
-	
-	#UTC
-	secondcounter -= (60*60*utc)
+def _gmst_radians(date_str, time_str, utc_offset, dst_hour):
+	"""Greenwich Mean Sidereal Time as an angle in radians."""
+	d = _schlyter_day(date_str, time_str, utc_offset, dst_hour)
+	# Schlyter's d = JD - 2451543.5, so days since J2000.0 UT = d - 1.5
+	t = d - 1.5
+	# Standard low-precision GMST (IAU 1982, fine for a poster starmap):
+	gmst_deg = (280.46061837 + 360.9856473662 * t) % 360
+	return math.radians(gmst_deg)
 
 
-	#calculate degree from days
-	degree = -((daycounter)*360.0/days_in_year) % 360
+def date_and_time_to_rad(date, time):
+	"""Per-frame RA offset (= -GMST) in radians."""
+	dst_hour = 1 if summertime else 0
+	return -_gmst_radians(date, time, utc, dst_hour)
 
-	#calculate degree from seconds
-	degree -= ((secondcounter)*360/(24*60*60)) % 360
 
-	return math.radians(degree)
+def julian_centuries_since_j2000(date_str, time_str, utc_offset, dst_hour):
+	"""Julian centuries from J2000.0 UT — used by the precession transform."""
+	d = _schlyter_day(date_str, time_str, utc_offset, dst_hour)
+	return (d - 1.5) / 36525.0
+
+
+def precess_j2000_to_date(ra_rad, dec_rad, T):
+	"""Apply J2000 -> epoch-of-date precession (Meeus ch.21, rigorous form)."""
+	# Precession angles in arcseconds
+	zeta  = (2306.2181*T + 0.30188*T*T + 0.017998*T*T*T)
+	z     = (2306.2181*T + 1.09468*T*T + 0.018203*T*T*T)
+	theta = (2004.3109*T - 0.42665*T*T - 0.041833*T*T*T)
+	# Arcseconds -> radians
+	as_to_rad = math.pi / (180.0 * 3600.0)
+	zeta  *= as_to_rad
+	z     *= as_to_rad
+	theta *= as_to_rad
+
+	cos_dec = math.cos(dec_rad)
+	sin_dec = math.sin(dec_rad)
+	cos_ra_zeta = math.cos(ra_rad + zeta)
+	sin_ra_zeta = math.sin(ra_rad + zeta)
+
+	A = cos_dec * sin_ra_zeta
+	B = math.cos(theta) * cos_dec * cos_ra_zeta - math.sin(theta) * sin_dec
+	C = math.sin(theta) * cos_dec * cos_ra_zeta + math.cos(theta) * sin_dec
+
+	ra_new = (math.atan2(A, B) + z) % (2.0 * math.pi)
+	dec_new = math.asin(max(-1.0, min(1.0, C)))
+	return ra_new, dec_new
 
 
 ########## GEOMETRY CALCULATION  ###########################################
@@ -507,6 +540,8 @@ def generate_starmap(northern_N,eastern_E,date,time):
 	E = math.radians(eastern_E)
 
 	raddatetime = date_and_time_to_rad(date,time)
+	dst_hour = 1 if summertime else 0
+	T_prec = julian_centuries_since_j2000(date, time, utc, dst_hour)
 	
 	if(guides is True):
 		draw_guides = []
@@ -540,9 +575,13 @@ def generate_starmap(northern_N,eastern_E,date,time):
 	for line in data:
 		if(line[2] < magnitude_limit):
 
-			#star position from datafile
-			ascension = right_ascension_to_rad(line[0])+raddatetime
-			declination = declination_to_rad(line[1])
+			#star position from datafile (J2000) -> epoch of date
+			ra_j2000  = right_ascension_to_rad(line[0])
+			dec_j2000 = declination_to_rad(line[1])
+			ra_now, dec_now = precess_j2000_to_date(ra_j2000, dec_j2000, T_prec)
+
+			ascension = ra_now + raddatetime
+			declination = dec_now
 
 			x,y = stereographic(N,E, declination, ascension, width-(borders))
 
@@ -569,26 +608,63 @@ def generate_starmap(northern_N,eastern_E,date,time):
 				print(counter)
 
 
+def _project_constellation_endpoint(N, E, ra_deg, dec_deg, raddatetime, T_prec):
+	"""Apply precession + time offset + stereographic projection to one endpoint."""
+	ra_j2000  = math.radians(ra_deg)
+	dec_j2000 = math.radians(dec_deg)
+	ra_now, dec_now = precess_j2000_to_date(ra_j2000, dec_j2000, T_prec)
+	ascension = ra_now + raddatetime
+	x, y = stereographic(N, E, dec_now, ascension, width - borders)
+	angle = angle_between(N, E, dec_now, ascension)
+	return x, y, angle
+
+
 def generate_constellations(northern_N,eastern_E,date,time):
 	N = math.radians(northern_N)
 	E = math.radians(eastern_E)
 
 	raddatetime = date_and_time_to_rad(date,time)
-	
+	dst_hour = 1 if summertime else 0
+	T_prec = julian_centuries_since_j2000(date, time, utc, dst_hour)
+
 	for line in constellation_lines:
-		ascension0 = right_ascension_to_rad(line[1])+raddatetime
-		declination0 = declination_to_rad(line[2])
-		x0,y0 = stereographic(N,E, declination0, ascension0, width-(borders))
+		x0, y0, a0 = _project_constellation_endpoint(N, E, line[1], line[2], raddatetime, T_prec)
+		x1, y1, a1 = _project_constellation_endpoint(N, E, line[3], line[4], raddatetime, T_prec)
 
-		ascension1 = right_ascension_to_rad(line[3])+raddatetime
-		declination1 = declination_to_rad(line[4])
-		x1,y1 = stereographic(N,E, declination1, ascension1, width-(borders))
+		if (a0 <= math.radians(90) and a1 <= math.radians(90)) or fullview:
+			draw_line(half_x-x0, half_y-y0, half_x-x1, half_y-y1, line_color)
 
-		angle_from_viewpoint1 = angle_between(N,E,declination0,ascension0)
-		angle_from_viewpoint2 = angle_between(N,E,declination1,ascension1)
 
-		if ((angle_from_viewpoint1 <= math.radians(90))  and (angle_from_viewpoint2 <= math.radians(90)) or fullview):
-			draw_line(half_x-x0,half_y-y0,half_x-x1,half_y-y1,line_color)
+def generate_constellation_names(northern_N, eastern_E, date, time):
+	"""Print each constellation's full name at the centroid of its visible segments."""
+	N = math.radians(northern_N)
+	E = math.radians(eastern_E)
+
+	raddatetime = date_and_time_to_rad(date, time)
+	dst_hour = 1 if summertime else 0
+	T_prec = julian_centuries_since_j2000(date, time, utc, dst_hour)
+
+	# Collect visible endpoints grouped by 3-letter IAU code.
+	groups = {}
+	for line in constellation_lines:
+		code = line[0]
+		for ra_deg, dec_deg in ((line[1], line[2]), (line[3], line[4])):
+			x, y, angle = _project_constellation_endpoint(N, E, ra_deg, dec_deg, raddatetime, T_prec)
+			if angle <= math.radians(90) or fullview:
+				groups.setdefault(code, []).append((half_x - x, half_y - y))
+
+	name_style = "font-size:3px; letter-spacing:1.5px; font-family:sans-serif; stroke-width:0; opacity:0.55;"
+	for code, pts in groups.items():
+		if len(pts) < 3:
+			# Too few visible endpoints -> likely at the horizon, label would be misleading.
+			continue
+		cx = sum(p[0] for p in pts) / len(pts)
+		cy = sum(p[1] for p in pts) / len(pts)
+		name = constellation_name_map.get(code, code).upper()
+		image.add(image.text(
+			name, insert=(cx, cy),
+			text_anchor='middle',
+			fill=constellation_color, style=name_style))
 
 def generate_planets(northern_N,eastern_E,date,time):
 	"""Draw Sun, Moon and the classical + outer planets for the given moment."""
@@ -631,6 +707,7 @@ if __name__ == '__main__':
 	read_ybsc5()
 	read_extra_star_coordinate_file()
 	read_constellation_file()
+	read_constellation_names()
 
 	half_x = mm_to_px(width/2)
 	half_y = mm_to_px(height/2)
@@ -645,6 +722,8 @@ if __name__ == '__main__':
 	generate_starmap(northern,eastern,date,time)
 	if constellation:
 		generate_constellations(northern,eastern,date,time)
+	if constellation_names:
+		generate_constellation_names(northern,eastern,date,time)
 	if planets:
 		generate_planets(northern,eastern,date,time)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,23 @@
+version = 1
+revision = 3
+requires-python = ">=3.8"
+
+[[package]]
+name = "starmap-svg"
+version = "0.2.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "svgwrite" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "svgwrite", specifier = ">=1.4" }]
+
+[[package]]
+name = "svgwrite"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/c1/263d4e93b543390d86d8eb4fc23d9ce8a8d6efd146f9427364109004fa9b/svgwrite-1.4.3.zip", hash = "sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3", size = 189516, upload-time = "2022-07-14T14:05:26.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/15/640e399579024a6875918839454025bb1d5f850bb70d96a11eabb644d11c/svgwrite-1.4.3-py3-none-any.whl", hash = "sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d", size = 67122, upload-time = "2022-07-14T14:05:24.459Z" },
+]


### PR DESCRIPTION
Completes the two items in the README `## TODO` and closes the two open issues, plus a small devex change (uv).

## Summary
- **Planets & Moon** (README TODO): new `-planets` flag draws Sun, Moon and Mercury…Neptune using Paul Schlyter's simplified Keplerian algorithm + the main solar perturbations of the Moon. Each body is labelled and culled by the same local-horizon check used for stars.
- **Automated summertime** (README TODO): `-summertime` now accepts `auto` (default), `true`, `false`. Auto applies the EU DST rule in the northern hemisphere and the AU-style rule in the southern hemisphere. Also fixes argparse's `type=bool`, which treated any non-empty string as `True`.
- **Constellation names** (closes #3): new `-constellation_names` flag prints each constellation's full name at the centroid of its visible line endpoints, using the existing `datafiles/constellation.txt`.
- **Alignment** (closes #2): two independent fixes — a BSC5 parsing bug (the actual root cause), plus a proper sky-rotation formula.
- **uv**: adds `pyproject.toml` / `uv.lock`; README now documents `uv sync` and `uv run python starmap.py -h`. `pip install svgwrite` still works.

## Why #2 happened
The Yale BSC5 star loader was reading each star's RA/Dec block as a fused decimal:
```python
dec = float(line[83:86] + '.' + line[87:90])   # "+35" + "." + "714"
```
For HR 337 (Mirach) this produced Dec = 35.714° instead of the catalog value 35°37′14″ = 35.6206°; RA seconds were also truncated to the nearest ten seconds. The constellation-line file is parsed correctly, so the two data sets drifted visibly apart — exactly the "slightly misaligned" symptom in the screenshot.

After the fix `read_ybsc5` honours the documented BSC5 byte layout and HR 337 parses to the catalog-exact `(17.4329°, +35.6206°)`.

The `calculation_mistake = -5.1` constant in `date_and_time_to_rad` was also replaced with the IAU 1982 low-precision GMST formula
`280.46061837 + 360.9856473662 × days_since_J2000_UT`,
and J2000 → epoch-of-date precession (Meeus ch. 21) is applied to both star and line coordinates. This doesn't fix #2 on its own (both stars and lines shared the same rotation error), but it keeps the chart's sky orientation correct across decades.

## Verification
- Sun position at 1990-04-19 00h UT → `RA 1h46m38s, Dec +11.01°`, matching Schlyter's worked example exactly.
- HR 337 (Mirach) parses to the J2000 catalog values bit-for-bit.
- Auto-DST spot-checked for northern hemisphere summer/winter and southern hemisphere summer/winter (Sydney).
- Full render works via \`uv run python starmap.py …\` for the existing README examples and the new combined example.

## Usage additions
\`\`\`
-constellation_names [true|false]   print each constellation's full name
-planets             [true|false]   draw Sun, Moon and planets
-summertime          [auto|true|false]   DST mode (auto is the new default)
\`\`\`

## Files
- \`starmap.py\` — all feature and bug-fix work
- \`pyproject.toml\`, \`uv.lock\` — uv migration
- \`README.md\` — new flags, uv usage, brief notes on the algorithms used
- \`.gitignore\` — \`.venv/\`, \`__pycache__/\`, \`*.pyc\`

Closes #2, closes #3.